### PR TITLE
stop slide timer on series description

### DIFF
--- a/src/components/CarouselSlide.vue
+++ b/src/components/CarouselSlide.vue
@@ -34,6 +34,7 @@ const props = defineProps({
     required: false,
   },
 })
+const emit = defineEmits(['slide-content-mouseenter', 'slide-content-mouseleave'])
 
 const genres = computed(() => props.genres.join(', '))
 </script>
@@ -42,7 +43,11 @@ const genres = computed(() => props.genres.join(', '))
   <li>
     <img class="image-background" :src="props.src" :alt="props.alt" />
     <div class="slide-content">
-      <div class="wrapper">
+      <div
+        class="wrapper"
+        @mouseenter="emit('slide-content-mouseenter')"
+        @mouseleave="emit('slide-content-mouseleave')"
+      >
         <img class="logo" :src="props.logo" alt="Anime Logo" />
         <div class="tags">
           <div class="age-rating">

--- a/src/components/ImageCarousel.vue
+++ b/src/components/ImageCarousel.vue
@@ -57,15 +57,14 @@ const onNextBtnClick = () => {
   changeSlideInterval.resume()
 }
 
-const onSlideBtnMouseOver = () => {
+const pauseSlideTimer = () => {
   changeSlideInterval.pause()
   progressBarInterval.pause()
-
   const elapsedTime = INIT_SLIDE_DURATION_MS * (progressBarWidth.value / 100)
   slideDurationMs.value = INIT_SLIDE_DURATION_MS - elapsedTime
 }
 
-const onSlideBtnMouseOut = () => {
+const resumeSlideTimer = () => {
   changeSlideInterval.resume()
   progressBarInterval.resume()
 }
@@ -87,6 +86,8 @@ watch(activeSlideIdx, () => {
           :key="key"
           v-bind="slide"
           v-show="key === activeSlideIdx"
+          @slide-content-mouseenter="pauseSlideTimer"
+          @slide-content-mouseleave="resumeSlideTimer"
         />
       </TransitionGroup>
       <div class="slide-pagination-buttons">
@@ -96,8 +97,8 @@ watch(activeSlideIdx, () => {
           class="slide-pagination-btn"
           :class="{ 'active-slide-pagination-btn': idx === activeSlideIdx }"
           @click="activeSlideIdx = idx"
-          @mouseover="onSlideBtnMouseOver"
-          @mouseout="onSlideBtnMouseOut"
+          @mouseenter="pauseSlideTimer"
+          @mouseleave="resumeSlideTimer"
         >
           <div
             class="slide-progress-bar"


### PR DESCRIPTION
- use `mouseenter` and `mouseleave` events instead of `mouseover` and `mouseout`
- when we hover over a slide content - the slide timer stops